### PR TITLE
Fix de cierre de socket

### DIFF
--- a/lib/perfil/profile.dart
+++ b/lib/perfil/profile.dart
@@ -322,11 +322,11 @@ class MapScreenState extends State<ProfilePage>
                                 onPressed: () async {
                                   //Comprobación cierre de sesión
                                   if (await _authService.logout()) {
+                                    removeValuesPersistence();
+                                    disconnectWebSocket();
                                     Navigator.of(context)
                                         .pushNamedAndRemoveUntil('/',
                                             (Route<dynamic> route) => false);
-                                    removeValuesPersistence();
-                                    disconnectWebSocket();
                                   } else {
                                     showDialog(
                                       barrierDismissible: false,

--- a/lib/popUps/deleteAccount.dart
+++ b/lib/popUps/deleteAccount.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gatovidapp/popUps/error.dart';
 import 'package:gatovidapp/services/auth.dart';
+import 'package:gatovidapp/services/websockets.dart';
 import 'package:gatovidapp/services/persistance.dart';
 
 Color blackWords = Color(0xff000000);
@@ -45,6 +46,7 @@ class DeleteAccount extends StatelessWidget {
                 //Comprobación borrar cuenta
                 if (await _authService.removeUser()) {
                   removeValuesPersistence();
+                  disconnectWebSocket();
                   Navigator.of(context).pushNamedAndRemoveUntil(
                       '/', (Route<dynamic> route) => false);
                 } else {


### PR DESCRIPTION
Subo un par de cambios dado que al cerrar sesion o eliminar cuenta, al no borrar el socket antes de llamar a la función de ir al "/" no se hace y por tanto no cierra, lo cual produce que haya varios websockets abiertos si se cierra sesion y se abre con otra