### PR TITLE
Fix de quedarse solo y no se acababa la partida

### DIFF
--- a/lib/services/websockets.dart
+++ b/lib/services/websockets.dart
@@ -71,6 +71,7 @@ void gameCancelledHandler() {
   globalError = Error(
       error:
           'No se ha podido encontrar una partida, por favor, intentelo de nuevo');
+  controlGame.add(true);
 }
 
 void usersWaitingHandler(int data) {


### PR DESCRIPTION
Probando la app, me he fijado que cuando se quedaba solo en la partida y llega el game_cancelled habia cometido un error y no se acababa